### PR TITLE
Add support for controls whose parent is not the uifigure.

### DIFF
--- a/mlapptools.m
+++ b/mlapptools.m
@@ -98,7 +98,11 @@ classdef (Abstract) mlapptools
         % A method for obtaining the webwindow handle and the widgetID corresponding 
         % to the provided uifigure control.
             % Get a handle to the webwindow
-            win = mlapptools.getWebWindow(uiElement.Parent);
+            p = uiElement.Parent;
+            while ~isa(p,'matlab.ui.Figure')
+              p = p.Parent;
+            end
+            win = mlapptools.getWebWindow(p);
             
             % Find which element of the DOM we want to edit
             widgetID = mlapptools.getWidgetID(win, mlapptools.getDataTag(uiElement));


### PR DESCRIPTION
This allows, for example, a text area inside a panel, to have the text
formatted with bold face font.  Previously this caused an error.

f = uifigure('Position', [680 558 560 420]);
p = uipanel(f,'Position',[20 20 520 380]);
txa = uitextarea(p, ...
'Value', 'Lorem ipsum', ...
'Position',[20 20 480 340]);
mlapptools.fontWeight(txa, 'bold');