### PR TITLE
Added 'uiswitch', 'uitoggleswitch', 'uirockerswitch' to getWebElements()

### DIFF
--- a/mlapptools.m
+++ b/mlapptools.m
@@ -189,7 +189,8 @@ classdef (Abstract) mlapptools
                 warnState = mlapptools.toggleWarnings('off');
                 widgetID = WidgetID('data-test-id', char(struct(uiElement).NodeId));
                 warning(warnState); % Restore warning state
-              case {'uipanel','figure','uitabgroup','uitab'}
+              case {'uipanel', 'figure', 'uitabgroup', 'uitab',  ...
+                'uiswitch', 'uitoggleswitch', 'uirockerswitch'}
                 widgetID = WidgetID('data-tag', mlapptools.getDataTag(uiElement));
               otherwise % default:              
                 widgetID = mlapptools.getWidgetID(win, mlapptools.getDataTag(uiElement));


### PR DESCRIPTION
I added expressions to existing case in `getWebElements()` for UISwitch elements. 

## Description
I added these classes to the case expression in the `getWebEleents` method. UISwitch elements use `<data-tag=#>` for unique identifiers like the `uipanel`, thus I've added the 3 `uiswitch` class names, `{'uiswitch', 'uitoggleswitch', 'uirockerswitch' }`to the case expression cell.

## Motivation and Context
Prior to adding these classes to the case expression, an incorrect widgetID was retrieved for classes, `'uiswitch', 'uitoggleswitch', 'uirockerswitch' `. Now the correct widgetID is retrieved for these UI elements.

## How Has This Been Tested?
I have tested this extensively in release 2018a by placing uiswitch elements and getting their widgetID for various purposes. No actual functional parts of code were changed, this just now lets more UI elements be selected through the api. No other code is apparently changed.

## Screenshots (if appropriate):
N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
